### PR TITLE
Simplifications and fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,12 @@
     "python.testing.pytestEnabled": true,
     "python.linting.banditEnabled": true,
     "python.linting.pylintEnabled": false,
-    "python.linting.banditArgs": ["-c pyproject.toml"]
+    "python.linting.banditArgs": ["-c pyproject.toml"],
+    "python.linting.mypyArgs": [
+        "--follow-imports=silent",
+        "--ignore-missing-imports",
+        "--show-column-numbers",
+        "--no-pretty",
+        "--check-untyped-defs"
+    ]
 }

--- a/my_cli/cli.py
+++ b/my_cli/cli.py
@@ -36,8 +36,9 @@ def zoo(
         "They're *in* the computer?",
         "They're break-dance fighting.",
     ]
-    # We can read persistent options from the config file directly.
-    quotes = [x for x in quotes if config.favorite.lower() in x.lower()]
+    if config.favorite:
+        # We can read persistent options from the config file directly.
+        quotes = [x for x in quotes if config.favorite.lower() in x.lower()]
 
     if quotes:
         print(random.choice(quotes))

--- a/my_cli/cli.py
+++ b/my_cli/cli.py
@@ -18,10 +18,14 @@ app = typer.Typer(help=__doc__)
 
 
 @app.command(name="zoo")
-def zoo(favorite: Optional[str] = None) -> None:
+def zoo(
+    favorite: Optional[str] = typer.Option(  # noqa: B008
+        config.favorite, help="A word from your favorite quote."
+    )
+) -> None:
     """Print a random quote from Zoolander."""
     if favorite is not None:
-        # If an option is passed, write to the config file.
+        # If an option is passed, write it to the config file.
         config.dump(favorite=favorite)
 
     quotes = [

--- a/my_cli/cli.py
+++ b/my_cli/cli.py
@@ -1,6 +1,7 @@
 """Help message for my CLI app. Change this."""
 
 
+import logging
 import random
 from pathlib import Path
 from typing import Optional
@@ -9,62 +10,38 @@ import typer
 
 from my_cli.config import Config
 
+APP_NAME = "my-cli"  # change this
+
+
 # Persistent user config
-config = Config()
+config = Config(Path(typer.get_app_dir(APP_NAME)) / "config.json")
 config.load()
 
-# Commands.
+# App object enclosing the commands.
 app = typer.Typer(help=__doc__)
 
+# An option that sync its values to the config file.
+# $ my-cli --favorite=hansel  # write 'favorite=value' to config file
+# $ my-cli                    # reuse from config file
+# $ my-cli --favorite=        # reset favorite
+FavoriteOption = config.option("favorite", help="Favorite quote.")
 
-@app.command(name="zoo")
-def zoo(
-    favorite: Optional[str] = typer.Option(  # noqa: B008
-        config.favorite, help="A word from your favorite quote."
-    )
-) -> None:
+
+@app.command()
+def quote(favorite: Optional[str] = FavoriteOption) -> None:
     """Print a random quote from Zoolander."""
-    if favorite is not None:
-        # If an option is passed, write it to the config file.
-        config.dump(favorite=favorite)
-
-    quotes = [
-        "It's that damn Hansel! He's so hot right now!",
-        "Hansel... so hot right now... Hansel.",
-        "Mugatu is so hot right now",
-        "What is this? A center for ants?",
-        "They're *in* the computer?",
-        "They're break-dance fighting.",
-    ]
-    if config.favorite:
-        # We can read persistent options from the config file directly.
-        quotes = [x for x in quotes if config.favorite.lower() in x.lower()]
-
-    if quotes:
-        print(random.choice(quotes))
-    else:
-        print("You've done nothing! NOTHIIIING!")
-
-
-# Sub commands under 'my-cli static' invocation.
-static = typer.Typer()
-app.add_typer(static, name="static", help="Subcommand example.")
-
-
-@static.command("list")
-def static_files() -> None:
-    """List static files."""
     # Static files will be in site-packages next to this file.
-    static_file_folder = Path(__file__).parent / "static"
-    for path in static_file_folder.iterdir():
-        print(path)
+    quotes_path = Path(__file__).parent / "static" / "my_quotes.txt"
+    quotes = quotes_path.read_text(encoding="utf-8").strip().split("\n")
 
+    # Filter quotes using the favorite filter.
+    if favorite:
+        logging.warning("favorite")
+        quotes = [x for x in quotes if favorite.lower() in x.lower()]
 
-@static.command("print")
-def static_print() -> None:
-    """List static files."""
-    static_file_folder = Path(__file__).parent / "static" / "my_static_file.txt"
-    print(static_file_folder.read_text(encoding="utf-8").strip())
+    # Random number generators in the standard library are not suitable for security.
+    # Drop the 'nosec' below and run 'hatch run lint:lint' to see lint checks in action.
+    print(random.choice(quotes or ["You've done nothing! NOTHIIIING!"]))  # nosec
 
 
 if __name__ == "__main__":

--- a/my_cli/config.py
+++ b/my_cli/config.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import typer
 
 APP_NAME = "my-cli"  # change this
-CONFIG_PATH = Path(typer.get_app_dir(APP_NAME)) / "config.json"
 
 
 @dataclass
@@ -21,16 +20,18 @@ class Config:
     invocations. See below for how to read and write to this configuration.
     """
 
+    PATH = Path(typer.get_app_dir(APP_NAME)) / "config.json"
+
     favorite: str = ""
     # add more serializable config values here
 
     def load(self):
         """Read config from config file."""
-        if CONFIG_PATH.is_file():
-            self.__init__(**dict(json.loads(CONFIG_PATH.read_text(encoding="utf-8"))))
+        if Config.PATH.is_file():
+            self.__init__(**dict(json.loads(Config.PATH.read_text(encoding="utf-8"))))
 
     def dump(self, **kwargs):
         """Write config back to config file."""
         self.__init__(**kwargs)
-        CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-        CONFIG_PATH.write_text(json.dumps(dataclasses.asdict(self)), encoding="utf-8")
+        Config.PATH.parent.mkdir(parents=True, exist_ok=True)
+        Config.PATH.write_text(json.dumps(dataclasses.asdict(self)), encoding="utf-8")

--- a/my_cli/config.py
+++ b/my_cli/config.py
@@ -5,6 +5,7 @@ import dataclasses
 import json
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
 import typer
 
@@ -22,7 +23,7 @@ class Config:
 
     PATH = Path(typer.get_app_dir(APP_NAME)) / "config.json"
 
-    favorite: str = ""
+    favorite: Optional[str] = None
     # add more serializable config values here
 
     def load(self):

--- a/my_cli/static/my_quotes.txt
+++ b/my_cli/static/my_quotes.txt
@@ -1,0 +1,6 @@
+It's that damn Hansel! He's so hot right now!
+Hansel... so hot right now... Hansel.
+Mugatu is so hot right now.
+What is this? A center for ants?
+They're *in* the computer?
+They're break-dance fighting.

--- a/my_cli/static/my_static_file.txt
+++ b/my_cli/static/my_static_file.txt
@@ -1,1 +1,0 @@
-Put static files in the 'static' folder and they will be bundled in your package.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ lint = [
   "flake8 .",
   "black . --check --diff",
   "isort . --check-only --diff",
-  "mypy .",
+  "mypy . --check-untyped-defs",
   "bandit -qr -c pyproject.toml .",
 ]
 fmt = [
@@ -77,7 +77,6 @@ test = [
 
 [tool.bandit]
 exclude_dirs = ["tests"]
-skips = ["B311"]  # delete to see bandit check
 
 [tool.isort]
 profile = "black"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,32 +14,40 @@ runner = CliRunner()
 @pytest.fixture
 def config(tmp_path: Path) -> cli.Config:
     """Fixture for config."""
+    cli.config.PATH = tmp_path / "config.json"
     return cli.config
 
 
-def test_bare() -> None:
+def test_bare(config: cli.Config) -> None:
     """Test invocation with no arguments."""
+    config.dump()
     result = runner.invoke(cli.app)
     assert result.exit_code != 0
     assert "Usage:" in result.stdout
 
 
-def test_help() -> None:
+def test_help(config: cli.Config) -> None:
     """Test help."""
+    config.dump()
     result = runner.invoke(cli.app, ["--help"])
     assert result.exit_code == 0
     assert "Usage:" in result.stdout
 
 
-def test_zoo():
+def test_zoo(config: cli.Config):
     """Test Zoolander quote."""
+    config.dump()
     result = runner.invoke(cli.app, ["zoo"])
     assert result.exit_code == 0
     assert len(result.stdout.strip().split("\n")) == 1
 
 
-def test_zoo_favorite():
+def test_zoo_favorite(config: cli.Config):
     """Test Zoolander quote."""
+    config.dump()
     result = runner.invoke(cli.app, ["zoo", "--favorite=break-dance"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "They're break-dance fighting."
+    result = runner.invoke(cli.app, ["zoo"])
     assert result.exit_code == 0
     assert result.stdout.strip() == "They're break-dance fighting."

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,42 +12,47 @@ runner = CliRunner()
 
 
 @pytest.fixture
-def config(tmp_path: Path) -> cli.Config:
+def test_config(tmp_path: Path) -> cli.Config:
     """Fixture for config."""
-    cli.config.PATH = tmp_path / "config.json"
+    cli.config = cli.Config(tmp_path / "config.json")
+    cli.config.dump()
     return cli.config
 
 
-def test_bare(config: cli.Config) -> None:
-    """Test invocation with no arguments."""
-    config.dump()
-    result = runner.invoke(cli.app)
-    assert result.exit_code != 0
-    assert "Usage:" in result.stdout
-
-
-def test_help(config: cli.Config) -> None:
+def test_help(test_config: cli.Config) -> None:
     """Test help."""
-    config.dump()
+    test_config.load()
     result = runner.invoke(cli.app, ["--help"])
     assert result.exit_code == 0
     assert "Usage:" in result.stdout
 
 
-def test_zoo(config: cli.Config):
+def test_quote(test_config: cli.Config):
     """Test Zoolander quote."""
-    config.dump()
-    result = runner.invoke(cli.app, ["zoo"])
+    test_config.load()
+    result = runner.invoke(cli.app)
     assert result.exit_code == 0
     assert len(result.stdout.strip().split("\n")) == 1
 
 
-def test_zoo_favorite(config: cli.Config):
+def test_favorite_quote(test_config: cli.Config):
     """Test Zoolander quote."""
-    config.dump()
-    result = runner.invoke(cli.app, ["zoo", "--favorite=break-dance"])
+    test_config.load()
+    print(test_config.path)
+    result = runner.invoke(cli.app, ["--favorite=break-dance"])
+    print(test_config.prefs)
     assert result.exit_code == 0
     assert result.stdout.strip() == "They're break-dance fighting."
-    result = runner.invoke(cli.app, ["zoo"])
+    print(test_config.path)
+    print(test_config.prefs)
+    result = runner.invoke(cli.app)
     assert result.exit_code == 0
     assert result.stdout.strip() == "They're break-dance fighting."
+
+
+def test_favorite_quote_missing(test_config: cli.Config):
+    """Test Zoolander quote."""
+    test_config.load()
+    result = runner.invoke(cli.app, ["--favorite=derek"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "You've done nothing! NOTHIIIING!"


### PR DESCRIPTION
- reduce to just one command that showcases everything
- simplify config, only need to specify options now
- config is stand-alone, one step closer to being a package of its own
- fix tests using prod config
- add a test for missing quote
- showcase bandit checks with 'nosec'
- enforce type checking in all functions